### PR TITLE
Fixes for running on modern systems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     'dearpygui-ext~=0.9.5',
     'midi_const~=0.1.0',
     'mido~=1.3.0', # FIXME: currently using custom 1.2.11a1 with EOX, running status and delta time support
-    'python-rtmidi~=1.4.9', # While it's mido's default backend, we explicitly require it for some features.
+    'python-rtmidi~=1.5.5', # While it's mido's default backend, we explicitly require it for some features.
     'Pillow~=9.5.0',
 ]
 license = { file = 'LICENSE' }

--- a/src/midiexplorer/gui/windows/about.py
+++ b/src/midiexplorer/gui/windows/about.py
@@ -111,7 +111,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.""")
 Used under the terms of the PSF License Agreement.""",
                      bullet=True)
 
-        dpg.add_text(f"""mido {mido.__version__}
+        dpg.add_text(f"""mido {mido.version_info}
 Copyright (c) 2013-infinity Ole Martin Bjørndalen
 Used under the terms of the MIT License.""",
                      bullet=True)

--- a/src/midiexplorer/midi/__init__.py
+++ b/src/midiexplorer/midi/__init__.py
@@ -28,7 +28,7 @@ def init() -> None:
     # MIDO and backend versions
     # -------------------------
     logger.log_debug("Using MIDO:")
-    logger.log_debug(f"\t - version: {mido.__version__}")
+    logger.log_debug(f"\t - version: {mido.version_info}")
     logger.log_debug(f"\t - backend: {mido.backend.name}")
 
     # -------------------------


### PR DESCRIPTION
Old versions of python-rtmidi fail to compile on modern systems:

      src/_rtmidi.cpp:243:12: fatal error: longintrepr.h: No such file or directory
        243 |   #include "longintrepr.h"
            |            ^~~~~~~~~~~~~~~
      compilation terminated.
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]

Newer version seems to work fine.

Also, newer mido versions removed the `__version__` attribute, replacing with `version_info`, which was introduced in [version 1.2.0 (2017-03-07)](https://mido.readthedocs.io/en/stable/changes.html#id12), from six years ago.

My system is Manjaro Linux with Python 3.11.3.