### PR TITLE
Typo in dependency name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = '>=3.10'
 # https://peps.python.org/pep-0508
 # https://peps.python.org/pep-0440/#version-specifiers
 dependencies = [
-    'dearpygu~=2.0.0',
+    'dearpygui~=2.0.0',
     'dearpygui-ext~=2.0.0',
     'midi_const~=0.1.0',
     'mido~=1.3.0', # FIXME: currently using custom 1.2.11a1 with EOX, running status and delta time support


### PR DESCRIPTION
Pip wasn't happy about nonexistent dep pygu :smile: 